### PR TITLE
makes sure a buffer `diff-hl-show-hunk-diff-buffer-name` exists...

### DIFF
--- a/diff-hl-show-hunk.el
+++ b/diff-hl-show-hunk.el
@@ -108,6 +108,9 @@ corresponding to the clicked line in the original buffer."
   (with-current-buffer (get-buffer-create diff-hl-show-hunk-buffer-name)
     (read-only-mode -1)
     (erase-buffer))
+  (with-current-buffer (get-buffer-create diff-hl-show-hunk-diff-buffer-name)
+    (read-only-mode -1)
+    (erase-buffer))
   (bury-buffer diff-hl-show-hunk-buffer-name)
   (bury-buffer diff-hl-show-hunk-diff-buffer-name)
   (when diff-hl-show-hunk--hide-function


### PR DESCRIPTION
before burying it. Not sure if this is the idiomatic solution for diff-hl, could maybe group it into a loop or maybe you're looking for an entirely different solution. either way, thanks for a cool mode and maybe this helps!

Fixes this error:

```
Debugger entered--Lisp error: (error "No such live buffer *diff-hl-show-hunk-diff-buffer...")
  signal(error ("No such live buffer *diff-hl-show-hunk-diff-buffer..."))
  error("No such live buffer %s" "*diff-hl-show-hunk-diff-buffer*")
  window-normalize-buffer("*diff-hl-show-hunk-diff-buffer*")
  bury-buffer("*diff-hl-show-hunk-diff-buffer*")
  diff-hl-show-hunk-hide()
  diff-hl-show-hunk()
  funcall-interactively(diff-hl-show-hunk)
  call-interactively(diff-hl-show-hunk record nil)
  command-execute(diff-hl-show-hunk record)
  execute-extended-command(nil "diff-hl-show-hunk" nil)
  funcall-interactively(execute-extended-command nil "diff-hl-show-hunk" nil)
  call-interactively(execute-extended-command nil nil)
  command-execute(execute-extended-command)
```